### PR TITLE
Updating files for Saitek joysticks

### DIFF
--- a/EDForceFeedback/settings.json
+++ b/EDForceFeedback/settings.json
@@ -5,8 +5,8 @@
     "NOTES2": "The device search will match on either value",
     "Xbox One For Windows": "ProductGuid = 02dd045e-0000-0000-0000-504944564944  ProductName = 'Controller (Xbox One For Windows)'",
     "MSFF2": "ProductGuid = 001b045e-0000-0000-0000-504944564944  ProductName = 'SideWinder Force Feedback 2 Joystick'",
-    "Saitek Cyborg 3D Force Stick": "ProductGuid = ff1206a3-0000-0000-0000-504944564944",
-    "Saitek Cyborg Evo Force Stick": "ProductGuid = ffb506a3-0000-0000-0000-504944564944",
+    "Saitek Cyborg 3D Force": "ProductGuid = ff1206a3-0000-0000-0000-504944564944",
+    "Saitek Cyborg Evo Force": "ProductGuid = ffb506a3-0000-0000-0000-504944564944",
     "Teensy Boards": "ProductGuid = 230028de-0000-0000-0000-504944564944 ProductName = IMU"
   },
 

--- a/EDForceFeedback/settingsMSFFB2.json
+++ b/EDForceFeedback/settingsMSFFB2.json
@@ -5,8 +5,8 @@
     "NOTES2": "The device search will match on either value",
     "Xbox One For Windows": "ProductGuid = 02dd045e-0000-0000-0000-504944564944  ProductName = 'Controller (Xbox One For Windows)'",
     "MSFF2": "ProductGuid = 001b045e-0000-0000-0000-504944564944  ProductName = 'SideWinder Force Feedback 2 Joystick'",
-    "Saitek Cyborg 3D Force Stick": "ProductGuid = ff1206a3-0000-0000-0000-504944564944",
-    "Saitek Cyborg Evo Force Stick": "ProductGuid = ffb506a3-0000-0000-0000-504944564944",
+    "Saitek Cyborg 3D Force": "ProductGuid = ff1206a3-0000-0000-0000-504944564944",
+    "Saitek Cyborg Evo Force": "ProductGuid = ffb506a3-0000-0000-0000-504944564944",
     "Teensy Boards": "ProductGuid = 230028de-0000-0000-0000-504944564944 ProductName = IMU"
   },
 

--- a/EDForceFeedback/settingsXbox.json
+++ b/EDForceFeedback/settingsXbox.json
@@ -5,8 +5,8 @@
     "NOTES2": "The device search will match on either value",
     "Xbox One For Windows": "ProductGuid = 02dd045e-0000-0000-0000-504944564944  ProductName = 'Controller (Xbox One For Windows)'",
     "MSFF2": "ProductGuid = 001b045e-0000-0000-0000-504944564944  ProductName = 'SideWinder Force Feedback 2 Joystick'",
-    "Saitek Cyborg 3D Force Stick": "ProductGuid = ff1206a3-0000-0000-0000-504944564944",
-    "Saitek Cyborg Evo Force Stick": "ProductGuid = ffb506a3-0000-0000-0000-504944564944",
+    "Saitek Cyborg 3D Force": "ProductGuid = ff1206a3-0000-0000-0000-504944564944",
+    "Saitek Cyborg Evo Force": "ProductGuid = ffb506a3-0000-0000-0000-504944564944",
     "Teensy Boards": "ProductGuid = 230028de-0000-0000-0000-504944564944 ProductName = IMU"
   },
 

--- a/EDForceFeedback/settingsXboxAndCyborg.json
+++ b/EDForceFeedback/settingsXboxAndCyborg.json
@@ -5,8 +5,8 @@
     "NOTES2": "The device search will match on either value",
     "Xbox One For Windows": "ProductGuid = 02dd045e-0000-0000-0000-504944564944  ProductName = 'Controller (Xbox One For Windows)'",
     "MSFF2": "ProductGuid = 001b045e-0000-0000-0000-504944564944  ProductName = 'SideWinder Force Feedback 2 Joystick'",
-    "Saitek Cyborg 3D Force Stick": "ProductGuid = ff1206a3-0000-0000-0000-504944564944",
-    "Saitek Cyborg Evo Force Stick": "ProductGuid = ffb506a3-0000-0000-0000-504944564944",
+    "Saitek Cyborg 3D Force": "ProductGuid = ff1206a3-0000-0000-0000-504944564944",
+    "Saitek Cyborg Evo Force": "ProductGuid = ffb506a3-0000-0000-0000-504944564944",
     "Teensy Boards": "ProductGuid = 230028de-0000-0000-0000-504944564944 ProductName = IMU"
   },
 

--- a/EDForceFeedback/settingsXboxAndMSFFB2.json
+++ b/EDForceFeedback/settingsXboxAndMSFFB2.json
@@ -5,8 +5,8 @@
     "NOTES2": "The device search will match on either value",
     "Xbox One For Windows": "ProductGuid = 02dd045e-0000-0000-0000-504944564944  ProductName = 'Controller (Xbox One For Windows)'",
     "MSFF2": "ProductGuid = 001b045e-0000-0000-0000-504944564944  ProductName = 'SideWinder Force Feedback 2 Joystick'",
-    "Saitek Cyborg 3D Force Stick": "ProductGuid = ff1206a3-0000-0000-0000-504944564944",
-    "Saitek Cyborg Evo Force Stick": "ProductGuid = ffb506a3-0000-0000-0000-504944564944",
+    "Saitek Cyborg 3D Force": "ProductGuid = ff1206a3-0000-0000-0000-504944564944",
+    "Saitek Cyborg Evo Force": "ProductGuid = ffb506a3-0000-0000-0000-504944564944",
     "Teensy Boards": "ProductGuid = 230028de-0000-0000-0000-504944564944 ProductName = IMU"
   },
 


### PR DESCRIPTION
In reference to the error that does not recognize the Saitek joystick (#9) , it is because of the name indicated in the files, which ends with the word _stick_, but the PC does not recognize it as such.